### PR TITLE
Add per-page CSS and links

### DIFF
--- a/static/css/about.css
+++ b/static/css/about.css
@@ -1,0 +1,1 @@
+@import url('style.css');

--- a/static/css/contact.css
+++ b/static/css/contact.css
@@ -1,0 +1,1 @@
+@import url('style.css');

--- a/static/css/gallery.css
+++ b/static/css/gallery.css
@@ -1,0 +1,1 @@
+@import url('style.css');

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,0 +1,1 @@
+@import url('style.css');

--- a/static/css/offers.css
+++ b/static/css/offers.css
@@ -1,0 +1,1 @@
+@import url('style.css');

--- a/static/css/policies.css
+++ b/static/css/policies.css
@@ -1,0 +1,1 @@
+@import url('style.css');

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 
 {% block title %}| About Us{% endblock %}
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/about.css') }}">
+{% endblock %}
+
 
 {% block content %}
     <!-- Hero Section -->

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -4,6 +4,7 @@
 
 {% block head_extra %}
 <!-- Leaflet CSS for Map -->
+<link rel="stylesheet" href="{{ url_for('static', filename='css/contact.css') }}">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 {% endblock %}
 

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 
 {% block title %}| Gallery{% endblock %}
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/gallery.css') }}">
+{% endblock %}
+
 
 {% block content %}
     <!-- Page Header -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/index.css') }}">
     <!-- Add AOS library for scroll animations -->
     <link href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" rel="stylesheet">
 {% endblock %}

--- a/templates/offers.html
+++ b/templates/offers.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 
 {% block title %}| Special Offers{% endblock %}
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/offers.css') }}">
+{% endblock %}
+
 
 {% block content %}
     <!-- Page Header -->

--- a/templates/policies.html
+++ b/templates/policies.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 
 {% block title %}| Our Policies{% endblock %}
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/policies.css') }}">
+{% endblock %}
+
 
 {% block content %}
     <!-- Page Header -->


### PR DESCRIPTION
## Summary
- add new CSS files for each HTML page and have them inherit the main stylesheet
- link each new stylesheet from its HTML template

## Testing
- `python -m py_compile app.py`
- `flake8 app.py` *(fails: E302, W293 and other style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68526bbe06808323822a8c474af16336